### PR TITLE
docs: add skills.sh install badge and quick install to README

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,6 +1,12 @@
 # Installation — epitech-pre-eval
 
-## Prérequis
+## Méthode recommandée — `npx skills`
+
+```bash
+npx skills add Nico-TekToulouse/epitech-pre-eval-copilot -g -a github-copilot
+```
+
+## Méthode manuelle — Prérequis
 
 - GitHub Copilot CLI installé et configuré
 - Python 3.8+

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -2,6 +2,11 @@
 
 ## Méthode recommandée — `npx skills`
 
+### Prérequis
+
+- Node.js et npm installés (nécessaires pour utiliser `npx`)
+- GitHub Copilot CLI installé et configuré
+
 ```bash
 npx skills add Nico-TekToulouse/epitech-pre-eval-copilot -g -a github-copilot
 ```

--- a/README.md
+++ b/README.md
@@ -7,9 +7,7 @@ Pré-évalue automatiquement un projet étudiant Epitech à partir d'un **barèm
 
 ## ⚡ Installation rapide
 
-```bash
-npx skills add Nico-TekToulouse/epitech-pre-eval-copilot -g -a github-copilot
-```
+Utilisez la section [Installation](#installation) ci-dessous pour la commande `npx skills add` recommandée.
 
 ## Ce que ce skill produit
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,15 @@
 # epitech-pre-eval — Skill GitHub Copilot CLI
 
+[![Install with skills CLI](https://img.shields.io/badge/skills.sh-install-blue?logo=github)](https://skills.sh/Nico-TekToulouse/epitech-pre-eval-copilot)
+[![Agent Skills](https://img.shields.io/badge/agent--skills-compatible-green)](https://github.com/vercel-labs/skills)
+
 Pré-évalue automatiquement un projet étudiant Epitech à partir d'un **barème JSON** et du **code source** fourni.
+
+## ⚡ Installation rapide
+
+```bash
+npx skills add Nico-TekToulouse/epitech-pre-eval-copilot -g -a github-copilot
+```
 
 ## Ce que ce skill produit
 
@@ -32,7 +41,13 @@ TypeScript · JavaScript · Java · C · C++ · Python · Go · Rust
 
 ## Installation
 
-Voir [INSTALL.md](INSTALL.md).
+> Installation via la commande `npx skills` (recommandée) :
+>
+> ```bash
+> npx skills add Nico-TekToulouse/epitech-pre-eval-copilot -g -a github-copilot
+> ```
+
+Voir [INSTALL.md](INSTALL.md) pour les autres méthodes d'installation.
 
 ## Exemples de prompts
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,11 @@ Pré-évalue automatiquement un projet étudiant Epitech à partir d'un **barèm
 
 ## ⚡ Installation rapide
 
-Utilisez la section [Installation](#installation) ci-dessous pour la commande `npx skills add` recommandée.
+```bash
+npx skills add Nico-TekToulouse/epitech-pre-eval-copilot -g -a github-copilot
+```
+
+> Prérequis : **Node.js** et **npm** (qui fournit `npx`) doivent être installés. Voir https://nodejs.org/ si nécessaire.
 
 ## Ce que ce skill produit
 
@@ -40,6 +44,8 @@ TypeScript · JavaScript · Java · C · C++ · Python · Go · Rust
 ## Installation
 
 > Installation via la commande `npx skills` (recommandée) :
+>
+> Prérequis : **Node.js** et **npm** (qui fournit `npx`) doivent être installés. Voir https://nodejs.org/ si nécessaire.
 >
 > ```bash
 > npx skills add Nico-TekToulouse/epitech-pre-eval-copilot -g -a github-copilot


### PR DESCRIPTION
Ajoute le badge d'installation skills.sh et la section **⚡ Installation rapide** avec `npx skills add` pour améliorer la découvrabilité sur skills.sh.